### PR TITLE
replace regex matching content of setRefGender call with a simpler st…

### DIFF
--- a/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
+++ b/packages/rosaenlg-doc/doc/modules/ROOT/pages/changelog.adoc
@@ -11,6 +11,8 @@ https://keepachangelog.com/en/0.3.0/
 
 === Fixed
 
+* fix for security alert: "Polynomial regular expression used on uncontrolled data" in `packages/rosaenlg-pug-code-gen/src/index.js:948` CWE-1333 / CWE-400 / CWE-730
+
 === Changed
 
 ////

--- a/packages/rosaenlg-pug-code-gen/src/index.js
+++ b/packages/rosaenlg-pug-code-gen/src/index.js
@@ -945,9 +945,14 @@ Compiler.prototype = {
     // console.log(JSON.stringify(code));
 
     if (code.val.startsWith('setRefGender(')) {
-      const content = code.val.replace(/setRefGender\((.*)\)/, '$1');
-      // in order to be homogeneous with other expressions parsing
-      this.helper.extractWordCandidateFromSetRefGender(content);
+      const lastParenthesis = code.val.lastIndexOf(')');
+      if (lastParenthesis !== -1) {
+        // remove the setRefGender and its parentheses from the original value, without regex
+        const content = code.val.slice('setRefGender('.length, lastParenthesis) + code.val.slice(lastParenthesis + 1);
+
+        // in order to be homogeneous with other expressions parsing
+        this.helper.extractWordCandidateFromSetRefGender(content);
+      }
     }
 
     // Wrap code blocks with {}.


### PR DESCRIPTION
…ring manipulation

regex usage with greedy ) matching may trigger a high level security alert regarding ReDoS Fork Code scanning alerts #37

Thanks for contributing!

## Please check if the PR fulfills these requirements 👌:

- [X] Confirm the PR related to a dedicated issue
- [X] Confirm your PR corrects a single bug or implements a single feature
- [X] Your code is linted locally prior to submission
- [X] Your code is fully tested: 99% to 100% coverage
- [X] Everything is correct on [Sonar dashboard](https://sonarcloud.io/dashboard?id=RosaeNLG_rosaenlg)
- [X] Confirm your code is under Apache 2.0 license
- [X] Confirm your documentation is under CC-BY-4.0 license
- [X] Confirm license and copyright content is created/updated in each file (see `CONTRIBUTING.md`)
- [X] Confirm `changelog.adoc` is updated
- [X] If corrects vulnerabilities, confirm `changelog.adoc` contains CVE IDs

Also remember: each commit **MUST** contain a sign off message (see `CONTRIBUTING.md`) 🙄

## Indicate related issue: 

issue #...

## Explain what is done, scope, limitations etc.
replacement of basic string manipulation to remove \setRefGender( ) and get its content with string replace and slice, instead of a greedy regex triggering security alerts

## Does this PR introduce a breaking change? 😁
No